### PR TITLE
 #5: lowered the minimum deployment targets to iOS 8.0 and OS X 10.9

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## [0.2.0][] • 2015-06-06
 
 - #2: Changed `StateMachine` into a class (was a struct).
+- #5: Lowered the minimum deployment targets to iOS 8.0 and OS X 10.9.
 
 
 ## [0.1.0][] • 2015-04-29

--- a/SwiftyStateMachine.xcodeproj/project.pbxproj
+++ b/SwiftyStateMachine.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = StateMachine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = SwiftyStateMachine;
 				SKIP_INSTALL = YES;
@@ -548,6 +549,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = StateMachine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = SwiftyStateMachine;
 				SKIP_INSTALL = YES;
@@ -603,7 +605,7 @@
 				INFOPLIST_FILE = StateMachine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = SwiftyStateMachine;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -622,7 +624,7 @@
 				INFOPLIST_FILE = StateMachine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = SwiftyStateMachine;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
closes #5
