### PR TITLE
Xcode 7.3 warnings suppression.

### DIFF
--- a/StateMachine/StateMachine.swift
+++ b/StateMachine/StateMachine.swift
@@ -19,9 +19,9 @@
 /// transition.  The transition block is optional and it gets passed
 /// the `Subject` object as an argument.
 public protocol StateMachineSchemaType {
-    typealias State
-    typealias Event
-    typealias Subject
+    associatedtype State
+    associatedtype Event
+    associatedtype Subject
 
     var initialState: State { get }
     var transitionLogic: (State, Event) -> (State, (Subject -> ())?)? { get }


### PR DESCRIPTION
Got some warnings from the latest Xcode release, which suggested the following changes:
Use of 'typealias' to declare associated types is deprecated; use 'associatedtype' instead.

Please review.
johan
